### PR TITLE
Python3 requires parentheses around arguments of 'print'.

### DIFF
--- a/SLcode_py/SL_equation_elastic.py
+++ b/SLcode_py/SL_equation_elastic.py
@@ -182,8 +182,8 @@ def love_lm(num, group='m'):
   """
   num = num[:maxdeg]
   h = np.hstack(( 0, num.squeeze() ))
-  h_lm = [];
-  print group
+  h_lm = []
+  print (group)
   if group == 'l':
     # This is the standard for Jerry's code
     for l in range(maxdeg+1):
@@ -295,13 +295,13 @@ def calc_rot(L_in, _k, _k_tide, group='l'):
     L20 = L_in[3]
     L21 = L_in[4] 
     L22 = L_in[5]
-    print L22
+    print (L22)
   elif group == 'm':
-    print "WARN: hard-coded max l,m; will break!"
+    print ("WARN: hard-coded max l,m; will break!")
     L20 = L_in[2]
     L21 = L_in[maxdeg+2]
     L22 = L_in[2*maxdeg + 1]
-    print L22
+    print (L22)
   k_L = _k[1] # This has 256 values
   k_T = _k_tide[1] # This has 256 values
 
@@ -355,7 +355,7 @@ start_time = time.time()
 # Iteration criterion epsilon
 while (k < k_max) and (chi >= epsilon):
 
-  #print chi
+  #print (chi)
 
   # expand ocean function into spherical harmonics
   # in m-first ordering
@@ -467,14 +467,14 @@ while (k < k_max) and (chi >= epsilon):
   k += 1
 
 if chi < epsilon:
-  print 'Converged after iteration', k, 'Chi was', chi
+  print ('Converged after iteration', k, 'Chi was', chi)
 else:
-  print 'Did not yet converge.'
-  print 'Finished iteration', k, '; Chi was', chi
+  print ('Did not yet converge.')
+  print ('Finished iteration', k, '; Chi was', chi)
 
 end_time = time.time()
 
-print "Time elapsed in k loop", end_time - start_time
+print ("Time elapsed in k loop", end_time - start_time)
 
 # calculate the scaling to normalize the fingerprint (it's normalized to be
 # one on average, when averaged over the final ocean basin). 

--- a/SLcode_py/pyspharm.py
+++ b/SLcode_py/pyspharm.py
@@ -192,7 +192,7 @@ if __name__ == "__main__":
         vrtg = x.spectogrd(vrtspec)
         ug,vg = x.getuv(vrtspec,divspec)
         phig = x.spectogrd(phispec)
-        print 't=%6.2f hours: min/max %6.2f, %6.2f' % (t/3600.,vg.min(), vg.max())
+        print ('t=%6.2f hours: min/max %6.2f, %6.2f' % (t/3600.,vg.min(), vg.max()))
         # compute tendencies.
         tmpg1 = ug*(vrtg+f); tmpg2 = vg*(vrtg+f)
         ddivdtspec[:,nnew], dvrtdtspec[:,nnew] = x.getvrtdivspec(tmpg1,tmpg2)
@@ -233,13 +233,13 @@ if __name__ == "__main__":
         nnew = nold; nnow = nsav1; nold = nsav2
 
     time2 = time.clock()
-    print 'CPU time = ',time2-time1
+    print ('CPU time = ',time2-time1)
 
     # make a orthographic plot of potential vorticity.
     m = Basemap(projection='ortho',lat_0=45,lon_0=0)
     # dimensionless PV
     pvg = (0.5*hbar*grav/omega)*(vrtg+f)/phig
-    print 'max/min PV',pvg.min(), pvg.max()
+    print ('max/min PV',pvg.min(), pvg.max())
     lons1d = (180./np.pi)*x.lons; lats1d = (180./np.pi)*x.lats
     pvg,lons1d = addcyclic(pvg,lons1d)
     lons, lats = np.meshgrid(lons1d,lats1d)


### PR DESCRIPTION
Python2 doesn't care one way or the other, so the compatible thing to do is to have parentheses.